### PR TITLE
Fix test interferencies

### DIFF
--- a/src/test/java/com/bindschaedel/service/GroupServiceTest.java
+++ b/src/test/java/com/bindschaedel/service/GroupServiceTest.java
@@ -39,6 +39,7 @@ public class GroupServiceTest {
     @AfterEach
     public void clean() {
         groupService.removeAll();
+        clubService.removeAll();
     }
 
     @Test


### PR DESCRIPTION
Hi, 

this PR resolves #5, 

Your issue is that when testing GroupService you save entities to your ClubRepository and don't flush them afterwards. Therefore if the next executed test checks the repository's size expecting it to be empty it fails. (canSearchAllClubs, canSearchAllClubsWithResult, nullClubNotSaved, validClubIsSaved, canRemoveClub, canSearchByName)

The fact that your build succeeds or fails depending on the machine is most likely related to how the running JVM orders the test execution.