### PR TITLE
Integration tests for global exception handler

### DIFF
--- a/src/test/java/com/bindschaedel/controller/util/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bindschaedel/controller/util/GlobalExceptionHandlerTest.java
@@ -1,0 +1,45 @@
+package com.bindschaedel.controller.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.TransactionSystemException;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GlobalExceptionHandlerTest {
+    private MockMvc mockMvc;
+
+    @Mock
+    private MockController mockController;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(mockController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    public void transactionSystemExceptionsReturnBadRequestCode() throws Exception {
+        when(mockController.dummy()).thenThrow(new TransactionSystemException("msg"));
+
+        mockMvc.perform(get("/dummy")).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void numberFormatExceptionReturnBadRequestCode() throws Exception {
+        when(mockController.dummy()).thenThrow(new NumberFormatException("msg"));
+
+        mockMvc.perform(get("/dummy")).andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/bindschaedel/controller/util/MockController.java
+++ b/src/test/java/com/bindschaedel/controller/util/MockController.java
@@ -1,0 +1,13 @@
+package com.bindschaedel.controller.util;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MockController {
+
+    @GetMapping("/dummy")
+    public String dummy() {
+        return "";
+    }
+}


### PR DESCRIPTION
Commiting code testing the wiring of the exception handler class, as requested in #7 .
I strongly believe quite a bit of the logic implemented by the class under test is not its inherent responsibility and should be delegated to another class. I feel testing this altogether would get the test class dirty and I suggest refactoring to separate concerns and make testing easier.
I don't mind implementing said refactor if considered necessary :)